### PR TITLE
fix: update Dockerfile Go version to 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /app
 COPY go.mod go.sum ./


### PR DESCRIPTION
## Summary
- Update Dockerfile base image from `golang:1.21-alpine` to `golang:1.24-alpine`

## Motivation
v1.1.0 bumped `go.mod` to Go 1.24.0 (required by `likexian/whois`), but the Dockerfile was not updated, causing Docker build failures in GitHub Actions:

```
go: go.mod requires go >= 1.24.0 (running go 1.21.13; GOTOOLCHAIN=local)
```

## Test plan
- [ ] Run DNS Watchdog workflow via `workflow_dispatch` in jinushi-lp repo